### PR TITLE
refactor: move session handling to server on home page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,26 +1,15 @@
 // logarea user-uluo
 
-"use client";
-
-import { useEffect } from "react";
-import { signIn, signOut, useSession } from "next-auth/react";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { redirect } from "next/navigation";
 import { Card } from "@/components/ui/card";
 
-export default function Home() {
-  const { data: session, status } = useSession();
-
-  useEffect(() => {
-    if (status === "unauthenticated") {
-      signIn("keycloak");
-    }
-  }, [status]);
-
-  if (status === "loading") {
-    return <p>Loading...</p>;
-  }
+export default async function Home() {
+  const session = await getServerSession(authOptions);
 
   if (!session) {
-    return null;
+    redirect("/api/auth/signin");
   }
 
   return (
@@ -31,3 +20,4 @@ export default function Home() {
     </div>
   );
 }
+


### PR DESCRIPTION
## Summary
- convert home page into server component
- redirect unauthenticated users to the sign-in page

## Testing
- `pnpm lint` (fails: How would you like to configure ESLint?)

------
https://chatgpt.com/codex/tasks/task_e_68a1b1f0229c833399b02c752d84f64d